### PR TITLE
Add constants to main plugin file

### DIFF
--- a/avh.php
+++ b/avh.php
@@ -10,19 +10,23 @@ Author URI:
 License:
 */
 
+define( 'ALCATRAZ_HOOK_GUIDE', '1.0.0' );
+define( 'ALCATRAZ_HOOK_GUIDE_PATH', plugin_dir_path( __FILE__ ) );
+define( 'ALCATRAZ_HOOK_GUIDE_URL', plugin_dir_url( __FILE__ ) );
+
 register_activation_hook(__FILE__, 'avh_activation_check');
 function avh_activation_check() {
 
-	    $theme_info = wp_get_theme();
+		$theme_info = wp_get_theme();
 
-	    	$alcatraz_flavors = array(
+			$alcatraz_flavors = array(
 			'Alcatraz',
 		);
 
-        if ( ! in_array( $theme_info->Template, $alcatraz_flavors ) ) {
-            deactivate_plugins( plugin_basename(__FILE__) ); // Deactivate ourself
-	        wp_die('Sorry, you can\'t activate unless you have installed <a href="http://www.alcatraztheme.org">Alcatraz</a>');
-        }
+		if ( ! in_array( $theme_info->Template, $alcatraz_flavors ) ) {
+			deactivate_plugins( plugin_basename(__FILE__) ); // Deactivate ourself
+			wp_die('Sorry, you can\'t activate unless you have installed <a href="http://www.alcatraztheme.org">Alcatraz</a>');
+		}
 
 }
 
@@ -69,10 +73,8 @@ global $wp_admin_bar;
 add_action('wp_enqueue_scripts', 'alcatraz_hooks_stylesheet');
 function alcatraz_hooks_stylesheet() {
 
-	 $alcatraz_hooks_plugin_url = plugins_url() . '/alcatraz-visual-hooks/';
-
 	 if ( 'show' == isset( $_GET['alcatraz_hooks'] ) )
-	 	wp_enqueue_style( 'avh_styles', $alcatraz_hooks_plugin_url . 'styles.css' );
+		 wp_enqueue_style( 'avh_styles', ALCATRAZ_HOOK_GUIDE_URL . 'styles.css' );
 }
 
 add_action('get_header', 'alcatraz_hooker' );


### PR DESCRIPTION
I added constants to the top of the PHP file.

It's a good idea to define these, especially in the case where we are pulling things from Github because it removes the dependency of the plugin directory having the exact same name. When I initially activated the plugin, I didn't see the styles because I didn't name my directory `/alcatraz-visual-hooks/`. Once I replaced it with the constant, it worked!

This plugin is great! Nice work, Jordan!
